### PR TITLE
Test 시 체크포인트 수정 및 스크립트 파일 추가

### DIFF
--- a/code/cycle_gan/run_test.sh
+++ b/code/cycle_gan/run_test.sh
@@ -1,0 +1,3 @@
+set -ex # 에러 났을 경우 멈춤 -e / -x 쉘스크립트 추적 (명령 수행하기에 앞서서 해당 커맨드 출력해줌) -> 같이 사용하면 에러 디버깅하기가 매우 수월.
+python code/cycle_gan/test.py --is_train False --data_root_A code/cycle_gan/horse2zebra/testA --data_root_B code/cycle_gan/horse2zebra/testB \
+                              --last_checkpoint_dir code/cycle_gan/weights/no_reflect_padding --exp_name no_reflect_padding --load_epoch 200

--- a/code/cycle_gan/run_train.sh
+++ b/code/cycle_gan/run_train.sh
@@ -1,0 +1,2 @@
+set -ex
+python train.py

--- a/code/cycle_gan/test.py
+++ b/code/cycle_gan/test.py
@@ -64,9 +64,9 @@ if __name__ == "__main__":
     G = Generator(init_channel=64, kernel_size=3, stride=2, n_blocks=9)
     F = Generator(init_channel=64, kernel_size=3, stride=2, n_blocks=9)
 
-    G, F, _, _, _ = load_checkpoint(os.path.join(opt.checkpoint_dir, f"epoch{opt.load_epoch}.pth"), G, F)
-
-    save_dir = os.path.join(opt.sample_save_dir, f"epoch{opt.load_epoch}")
+    G, F, _, _, _ = load_checkpoint(os.path.join(opt.last_checkpoint_dir, f"epoch{opt.load_epoch}.pth"), G, F)
+    
+    save_dir = os.path.join(opt.sample_save_dir, opt.exp_name, f"epoch{opt.load_epoch}")
     os.makedirs(save_dir, exist_ok=True)
 
     test(test_loader, G, F, device, save_dir)

--- a/code/cycle_gan/utils.py
+++ b/code/cycle_gan/utils.py
@@ -56,7 +56,7 @@ def parse_opt():
     parser.add_argument("--prj_name", type=str, default="cycle_gan")
     parser.add_argument("--exp_name", type=str, default="exp1")
     parser.add_argument("--log_interval", type=int, default=25)
-    parser.add_argument("--sample_save_dir", type=str, default='code/cycle_gan/results/')
+    parser.add_argument("--sample_save_dir", type=str, default='code/cycle_gan/test_results/')
     parser.add_argument("--last_checkpoint_dir", type=str, default="code/cycle_gan/weights/D_averaging")
     parser.add_argument("--checkpoint_dir", type=str, default="code/cycle_gan/weights")
     parser.add_argument("--load_epoch", type=int, default=150)


### PR DESCRIPTION
## Issues
- 기존의 체크포인트 directory를 그대로 이용할 경우, experiment 간의 구분이 되지 않는 문제가 발생. 따라서 기존의 결과를 overwrite할 가능성이 존재함. 
- 또한, last_checkpoint_dir를 사용해야 load가 제대로 이루어지는데 checkpoint_dir를 사용하면 path가 없다고 에러가 발생할 것.

## 변경 사항
- 결과를 저장할 경로를 exp_name과 join시켜주어서 experiment 별로 test 결과가 구분될 수 있도록 함.
- load_checkpoint에서 opt.checkpoint_dir를 opt.last_checkpoint_dir로 수정해줌.
- 인자를 보다 쉽게 작성할 수 있도록 shellscript를 작성해서 run파일 만들어줌.
